### PR TITLE
feat(home-UI):홈 화면 폰트 사이즈 조절 및 캘린더 dot 표시 추가

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -135,6 +135,14 @@ export default function HomeScreen() {
     return Math.round((done / total) * 100)
   }, [choresOfDay])
 
+  //집안일 있는 날짜 배열 만들기
+  const dotDates = useMemo(() => {
+    const s = new Set<string>()
+    chores.forEach((c) => s.add(c.dueDate))
+
+    return Array.from(s)
+  }, [chores])
+
   return (
     <>
       {/* StatusBar 색상 지정 */}
@@ -163,8 +171,8 @@ export default function HomeScreen() {
           <View className="bg-[#DDF4F6] px-5 py-3 rounded-2xl">
             <View className="flex-row items-center justify-between">
               <View className="flex gap-2">
-                <Text className="font-semibold text-[18px]">안녕하세요, 사용자님!</Text>
-                <Text className="text-[14px]">
+                <Text className="font-semibold text-xl">안녕하세요, 사용자님!</Text>
+                <Text className="text-base">
                   오늘의 집안일을 <Text className="font-bold text-[#46A1A6]">{progress}%</Text>{' '}
                   완료했어요.
                 </Text>
@@ -187,25 +195,30 @@ export default function HomeScreen() {
           </View>
 
           {/* 캘린더 */}
-          <View className="">
-            <HomeCalendar onSelect={setSelectedDate} />
+          <View>
+            <HomeCalendar onSelect={setSelectedDate} dotDates={dotDates} />
           </View>
           {/* 할일 내역 */}
           <View className="flex">
             <View className="flex-row gap-2 items-center mb-3">
-              <Text className="text-[18px] font-bold">{formatKoreanDate(selectedDate)}</Text>
-              <Text className="text-[16px]">집안일</Text>
+              <Text className="text-xl font-bold">{formatKoreanDate(selectedDate)}</Text>
+              <Text className="text-lg">집안일</Text>
             </View>
 
             <View className="bg-white rounded-2xl p-5">
               {choresOfDay.length === 0 ? (
                 <Text className="text-base">사용자님의 하루 집안일을 계획해보세요</Text>
               ) : (
-                choresOfDay.map((item) => (
-                  <View key={item.id} className="flex-row items-center justify-between mb-3">
+                choresOfDay.map((item, index) => (
+                  <View
+                    key={item.id}
+                    className={`flex-row items-center justify-between ${
+                      choresOfDay.length === 1 || index === choresOfDay.length - 1 ? '' : 'mb-3'
+                    }`}
+                  >
                     <View className="flex-row gap-3 items-center">
                       <Text
-                        className={`rounded-[6px] px-2 py-1 text-xs ${
+                        className={`rounded-[6px] px-2 py-[2px] text-sm ${
                           item.status === 'COMPLETED'
                             ? 'bg-[#CDCFD2] text-[#9B9FA6] '
                             : 'bg-[#DDF4F6] text-[#46A1A6] '

--- a/components/Calendar/HomeCalendar.tsx
+++ b/components/Calendar/HomeCalendar.tsx
@@ -1,6 +1,5 @@
-import { MaterialIcons } from '@expo/vector-icons'
 import { useMemo, useState } from 'react'
-import { Text, TextStyle, TouchableOpacity, View, ViewStyle } from 'react-native'
+import { Image, Text, TextStyle, TouchableOpacity, View, ViewStyle } from 'react-native'
 import { Calendar, LocaleConfig } from 'react-native-calendars'
 import { MarkedDates } from 'react-native-calendars/src/types'
 
@@ -44,9 +43,10 @@ LocaleConfig.defaultLocale = 'ko'
 
 type Props = {
   onSelect?: (dateString: string) => void // 선택 날짜 부모로 올려줄 콜백
+  dotDates?: string[]
 }
 
-export default function HomeCalendar({ onSelect }: Props) {
+export default function HomeCalendar({ onSelect, dotDates = [] }: Props) {
   // 오늘
   const todayStr = useMemo(() => toYMD(new Date()), [])
   // 선택된 날짜(초기: 오늘)
@@ -54,20 +54,39 @@ export default function HomeCalendar({ onSelect }: Props) {
   // 보이는 달(초기: 오늘이 속한 달의 1일)
   const [currentMonthStr, setCurrentMonthStr] = useState<string>(() => toFirstDayOfMonth(todayStr))
 
+  // 점 표시할 날짜
+  const dotSet = useMemo(() => new Set(dotDates), [dotDates])
+
   // 테마
   const themeObj = useMemo(
     () => ({
-      textDayFontSize: 14,
+      textDayFontSize: 16,
       textDayHeaderFontSize: 14,
-      textMonthFontSize: 16,
+      textMonthFontSize: 18,
       textMonthFontWeight: '700',
       monthTextColor: '#0F172A',
       arrowColor: '#57C9D0',
+      // 주(week) 줄
       'stylesheet.calendar.main': {
         week: {
           flexDirection: 'row',
           justifyContent: 'space-between',
-          marginVertical: 2,
+          marginVertical: 0,
+        },
+      },
+      // 헤더 영역
+      'stylesheet.calendar.header': {
+        header: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 16,
+        },
+
+        dayHeader: {
+          fontSize: 14,
+          marginBottom: 16,
+          color: '#040F2080',
         },
       },
     }),
@@ -94,7 +113,6 @@ export default function HomeCalendar({ onSelect }: Props) {
     if (!selectedDate) return {}
     return {
       [selectedDate]: {
-        // TS가 customStyles를 모를 수 있어서 any/캐스팅 처리
         customStyles: {
           container: { backgroundColor: '#57C9D0', borderRadius: 8 } as ViewStyle,
           text: { color: '#fff', fontWeight: '700' } as TextStyle,
@@ -104,100 +122,102 @@ export default function HomeCalendar({ onSelect }: Props) {
   }, [selectedDate])
 
   return (
-    <View style={{ borderRadius: 12, overflow: 'hidden' }}>
-      <View style={{ borderRadius: 12, overflow: 'hidden' }}>
-        <Calendar
-          key={calendarKey}
-          current={currentMonthStr}
-          onMonthChange={(d) => {
-            const first = `${d.year}-${String(d.month).padStart(2, '0')}-01`
-            setCurrentMonthStr(first)
-          }}
-          onDayPress={(d) => {
-            onSelect?.(d.dateString)
-            setSelectedDate(d.dateString)
-          }}
-          markingType="custom"
-          markedDates={markedDates}
-          theme={themeObj as any}
-          enableSwipeMonths
-          hideExtraDays
-          renderArrow={(direction) =>
-            direction === 'left' ? (
-              <MaterialIcons name="chevron-left" size={28} color="#57C9D0" />
-            ) : (
-              <MaterialIcons name="chevron-right" size={28} color="#57C9D0" />
-            )
-          }
-          renderHeader={(date) => {
-            const y = date.getFullYear()
-            const m = date.getMonth() + 1
-            return (
-              <View className="flex-row items-center justify-between px-5 py-3 gap-1">
-                <Text className="text-[16px] font-semibold text-[#040F20B2]">{`${y}년 ${m}월`}</Text>
-                {showTodayBtn && (
-                  <TouchableOpacity
-                    className="border border-[#57C9D0] rounded-md px-1 py-[2px]"
-                    onPress={goToday}
-                    activeOpacity={0.8}
-                  >
-                    <Text className="text-[#57C9D0]">오늘</Text>
-                  </TouchableOpacity>
+    <View className="rounded-2xl overflow-hidden">
+      <Calendar
+        key={calendarKey}
+        current={currentMonthStr}
+        onMonthChange={(d) => {
+          const first = `${d.year}-${String(d.month).padStart(2, '0')}-01`
+          setCurrentMonthStr(first)
+        }}
+        onDayPress={(d) => {
+          onSelect?.(d.dateString)
+          setSelectedDate(d.dateString)
+        }}
+        markingType="custom"
+        markedDates={markedDates}
+        theme={themeObj as any}
+        enableSwipeMonths
+        hideExtraDays
+        // PNG 화살표
+        renderArrow={(direction) =>
+          direction === 'left' ? (
+            <Image
+              source={require('../../assets/images/arrow/left.png')}
+              className="w-[14px] h-[14px]"
+              resizeMode="contain"
+            />
+          ) : (
+            <Image
+              source={require('../../assets/images/arrow/right.png')}
+              className="w-[14px] h-[14px]"
+              resizeMode="contain"
+            />
+          )
+        }
+        // 달력 바깥 여백
+        className="p-5"
+        // 헤더
+        renderHeader={(date) => {
+          const y = date.getFullYear()
+          const m = date.getMonth() + 1
+          return (
+            <View className="flex-row items-center justify-between gap-1">
+              <Text className="text-lg font-semibold text-[#040F20B2]">{`${y}년 ${m}월`}</Text>
+              {showTodayBtn && (
+                <TouchableOpacity
+                  className="border border-[#57C9D0] rounded-md px-1 py-[2px]"
+                  onPress={goToday}
+                  activeOpacity={0.8}
+                >
+                  <Text className="text-[#57C9D0]">오늘</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          )
+        }}
+        // 데이 셀
+        dayComponent={({ date, state, marking, onPress }) => {
+          const d = date
+          const isToday = d?.dateString === todayStr || state === 'today'
+          const baseColor = '#040F20'
+          const todayColor = '#57C9D0'
+          const fallbackTextColor = isToday ? todayColor : baseColor
+
+          const isSelected = d?.dateString === selectedDate
+
+          return (
+            <TouchableOpacity
+              activeOpacity={0.8}
+              onPress={() => onPress?.(date)}
+              className="flex-1 w-full h-full items-center justify-center"
+            >
+              <View
+                className="w-[90%] aspect-square rounded-lg items-center justify-center relative"
+                style={marking?.customStyles?.container}
+              >
+                <Text
+                  className="text-base font-normal"
+                  style={{
+                    includeFontPadding: false,
+                    textAlignVertical: 'center',
+                    color: fallbackTextColor,
+                    ...(marking?.customStyles?.text ?? {}),
+                  }}
+                >
+                  {d?.day}
+                </Text>
+
+                {d?.dateString && dotSet.has(d.dateString) && (
+                  <View
+                    className={`w-[5px] h-[5px] rounded-full absolute bottom-[6px] ${isSelected ? 'bg-white' : 'bg-[#57C9D0]'}`}
+                  />
                 )}
               </View>
-            )
-          }}
-          dayComponent={({ date, state, marking, onPress }) => {
-            const d = date
-            const isToday = d?.dateString === todayStr || state === 'today'
-            const baseColor = '#040F20'
-            const todayColor = '#57C9D0'
-            const fallbackTextColor = isToday ? todayColor : baseColor
-
-            return (
-              <TouchableOpacity
-                activeOpacity={0.8}
-                onPress={() => onPress?.(date)}
-                style={{
-                  flex: 1,
-                  width: '100%',
-                  height: '100%',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                <View
-                  style={[
-                    {
-                      width: '90%',
-                      aspectRatio: 1,
-                      borderRadius: 8,
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                    },
-                    marking?.customStyles?.container,
-                  ]}
-                >
-                  <Text
-                    style={[
-                      {
-                        fontSize: 14,
-                        includeFontPadding: false,
-                        textAlignVertical: 'center',
-                        color: fallbackTextColor,
-                        fontWeight: '400',
-                      },
-                      marking?.customStyles?.text,
-                    ]}
-                  >
-                    {d?.day}
-                  </Text>
-                </View>
-              </TouchableOpacity>
-            )
-          }}
-        />
-      </View>
+            </TouchableOpacity>
+          )
+        }}
+      />
     </View>
   )
 }


### PR DESCRIPTION
## Purpose
홈 화면의 가독성과 일정 가시성을 개선하기 위해
1) 홈 카드/텍스트의 폰트 사이즈를 조정
2) 캘린더에 집안일이 있는 날짜에 점(dot)을 표시

## Changes
- 홈 화면
  - 헤더/본문 타이포그래피 스케일 조정(`text-xl`, `text-base` 등) 및 여백 미세 튜닝
- 캘린더(HomeCalendar)
  - `dotDates?: string[]` prop 추가
  - 날짜 셀 하단 중앙에 **dot 1개** 표시(민트 `#57C9D0`)
  - 선택된 날짜(민트 사각형 배경)에서는 dot을 **흰색**으로 표시해 대비 확보

## How to test
1. 앱 실행 후 홈 화면 진입
2. 캘린더에서 다음 날짜에 **민트 dot** 표시 확인  
   `2025-10-02`, `2025-10-05`, `2025-10-07` (더미 데이터 기준)
3. dot이 있는 날짜를 탭하여 선택 → 선택된 날짜의 dot이 **흰색**으로 바뀌는지 확인
4. 월 전환/오늘 버튼 사용 시 dot 및 선택 상태가 정상적으로 반영되는지 확인
5. 동일 날짜의 집안일 개수와 무관하게 dot은 **1개만** 표시되는지 확인(의도)
6. 안드로이드/IOS 모두 숫자 위치는 중앙, dot은 숫자 **아래**에 고정되는지 확인

## Screenshots/GIF

<img width="359" height="757" alt="image" src="https://github.com/user-attachments/assets/61b60196-a422-4e03-95ff-81cdd381929c" />



